### PR TITLE
Updating QC metrics, adding bias plot

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -267,9 +267,9 @@ def plot_bias(behavior_json,results_folder):
 def main():
     # Paths and setup
     base_path = Path("/data/fiber_raw_data")
-    results_folder = Path("../results/aind-dynamic-foraging-qc")
+    results_folder = Path("../results/dynamic-foraging-qc")
     results_folder.mkdir(parents=True, exist_ok=True)
-    reference_folder = Path("aind-dynamic-foraging-qc")
+    reference_folder = Path("dynamic-foraging-qc")
     reference_folder.mkdir(parents=True, exist_ok=True)
 
     # Load JSON files
@@ -492,6 +492,8 @@ def main():
     else:
         session_length = timedelta(minutes=0)
 
+    session_length_seconds = session_length.total_seconds()
+
     evaluations.append(
         create_evaluation(
             "Session Length Check",
@@ -511,7 +513,7 @@ def main():
                 QCMetric(
                     name="Length of stimulus epoch",
                     description="Must be at least 10 minutes",
-                    value=session_length,
+                    value=session_length_seconds,
                     status_history=[
                         Bool2Status(
                             session_length > timedelta(minutes=10),

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -109,7 +109,7 @@ def calculate_lick_intervals(behavior_json):
         }
         return results
 
-def plot_bias(behavior_json):
+def plot_bias(behavior_json,results_folder):
     plt.figure()
     plt.xlabel('Time from first go cue(s)')
     plt.ylabel('Side Bias')
@@ -118,7 +118,7 @@ def plot_bias(behavior_json):
     plt.axhline(0,color='k', linestyle='--')
     plt.ylim([-1,+1]) 
 
-    if len(behavior_json['B_GoCueTime']) == len(behavior_json['B_GoCueTime'):
+    if len(behavior_json['B_Bias']) == len(behavior_json['B_GoCueTime']):
         plt.plot(np.array(behavior_json['B_GoCueTime'])-behavior_json['B_GoCueTime'][0],behavior_json['B_Bias'],'k',linewidth=2)
         start = 0
         stop = behavior_json['B_GoCueTime'][-1] - behavior_json['B_GoCueTime'][0]
@@ -151,7 +151,7 @@ def main():
     )
 
     session_json = load_json_file(base_path / "session.json")
-    plot_bias(behavior_json,results_folder)
+
  
     # Load behavior JSON
     # Regex pattern is <subject_id>_YYYY-MM-DD_HH-MM-SS.json
@@ -161,6 +161,9 @@ def main():
         behavior_json = load_json_file(matching_behavior_files[0])
     else:
         logging.info("NO BEHAVIOR JSON")
+
+    # Create bias plot
+    plot_bias(behavior_json,results_folder)
 
     # Create evaluations with our timezone
     seattle_tz = pytz.timezone("America/Los_Angeles")
@@ -349,8 +352,9 @@ def main():
                     value=session_length,
                     status_history=[
                         Bool2Status(
-                        session_length > timedelta(minutes=10),
-                        t=datetime.now(seattle_tz),
+                            session_length > timedelta(minutes=10),
+                            t=datetime.now(seattle_tz),
+                        )
                     ],
                 )
             ],

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -176,16 +176,17 @@ def main():
     else:
         logging.info("SKIPPING dropped frames check, no drop_frames_tag")
 
-    if "Experimenter" in behavior_json:
-        logging.info("Running check for researcher name")
+    if ("Experimenter" in behavior_json) and ("dirty_files" in behavior_json):
+        logging.info("Running check for basic configuration")
         evaluations.append(
             create_evaluation(
-                "Check researcher name",
-                "pass when researcher name is not default name",
+                "Basic Configuration",
+                "pass when researcher name is not default name, and code repo is clean",
                 [
                     QCMetric(
                         name="researcher name",
                         value=behavior_json["Experimenter"],
+                        description='Experimenter name should not be set to the default value of "the ghost in the shell"',
                         status_history=[
                             Bool2Status(
                                 behavior_json["Experimenter"]
@@ -193,22 +194,10 @@ def main():
                                 t=datetime.now(seattle_tz),
                             )
                         ],
-                    )
-                ],
-            )
-        )
-    else:
-        logging.info("SKIPPING check for researcher name, no Experimenter")
-
-    if "dirty_files" in behavior_json:
-        logging.info("Running check for untracked file changes")
-        evaluations.append(
-            create_evaluation(
-                "Check for untracked file changes",
-                "pass when no dirty files where in the code repository",
-                [
+                    ),
                     QCMetric(
                         name="untracked local changes",
+                        description='Whether the code base had untracked changes, and if so, which files',
                         value=behavior_json["dirty_files"],
                         status_history=[
                             Bool2Status(
@@ -221,7 +210,8 @@ def main():
             )
         )
     else:
-        logging.info("SKIPPING check for untracked file changes, no dirty_files")
+        logging.info("SKIPPING check for basic configuration")
+
 
     # Check side bias
     if "B_Bias" in behavior_json:

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -162,8 +162,8 @@ def plot_bias(behavior_json,results_folder):
             y1 = [x['y1'] for x in behavior_json['B_StagePositions']]
             y2 = [x['y2'] for x in behavior_json['B_StagePositions']]
         else:
-            y1 = [x['y'] for x in behavior_json['B_StagePositions']]
-            y2 = [x['y'] for x in behavior_json['B_StagePositions']] 
+            y1 = [x['y']*1000 for x in behavior_json['B_StagePositions']]
+            y2 = [x['y']*1000 for x in behavior_json['B_StagePositions']] 
 
         if len(behavior_json['B_Bias']) == len(behavior_json['B_GoCueTime']):
             ax[1].plot(behavior_json['B_GoCueTime'],np.array(x)[:-1]-x[0],'r',label='X')

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -215,15 +215,17 @@ def plot_bias(behavior_json,results_folder):
 
     if 'B_StagePositions' in behavior_json:
         # Extract stage positions
-        x = [x['x'] for x in behavior_json['B_StagePositions']]
-        z = [x['z'] for x in behavior_json['B_StagePositions']]
         if 'y1' in behavior_json['B_StagePositions'][0]:
+            x = [x['x'] for x in behavior_json['B_StagePositions']]
+            z = [x['z'] for x in behavior_json['B_StagePositions']]
             y1 = [x['y1'] for x in behavior_json['B_StagePositions']]
             y2 = [x['y2'] for x in behavior_json['B_StagePositions']]
         else:
             # Convert Newscale from um to mm
-            y1 = [x['y']*1000 for x in behavior_json['B_StagePositions']]
-            y2 = [x['y']*1000 for x in behavior_json['B_StagePositions']] 
+            x = [x['x']/1000 for x in behavior_json['B_StagePositions']]
+            z = [x['z']/1000 for x in behavior_json['B_StagePositions']]
+            y1 = [x['y']/1000 for x in behavior_json['B_StagePositions']]
+            y2 = [x['y']/1000 for x in behavior_json['B_StagePositions']] 
 
         # Plot stage positions
         ax[1].plot(np.array(x)[:-1]-x[0],'r',label='X')

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -294,6 +294,11 @@ def main():
         behavior_json = load_json_file(matching_behavior_files[0])
     else:
         logging.info("NO BEHAVIOR JSON, cannot run QC")
+        qc_file_path = results_folder / "no_behavior_to_qc.txt"
+        # Create an empty file
+        with open(qc_file_path, "w") as file:
+            file.write("No behavior JSON file, cannot run QC")
+        print(f"Empty file created at: {qc_file_path}")
         return
 
     # Create bias plot
@@ -517,8 +522,6 @@ def main():
             ],
         )
     )
-
-    # TODO - move files?
 
     # Create QC object and save
     qc = QualityControl(evaluations=evaluations)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -63,7 +63,7 @@ def create_evaluation(
 def calculate_lick_intervals(behavior_json):
     right = behavior_json["B_RightLickTime"]
     left = behavior_json["B_LeftLickTime"]
-    threshold = 0.1  # time in ms to consider as a fast interval
+    threshold = 0.05  # time in ms to consider as a fast interval
     same_side_l = np.diff(left)
     same_side_r = np.diff(right)
     if len(right) > 0:
@@ -77,7 +77,7 @@ def calculate_lick_intervals(behavior_json):
     if len(right) > 0 and len(left) > 0:
         # calculate same side lick interval and fraction for both right and left
         same_side_combined = np.concatenate([same_side_l, same_side_r])
-        same_side_frac = round(np.mean(same_side_combined <= threshold), 4)
+        same_side_frac = round(np.sum(same_side_combined <= threshold)/(len(right)+len(left)), 4)
         # calculate cross side interval and frac
         right_dummy = np.ones(np.shape(right))  # array used to assign lick direction
         left_dummy = np.negative(np.ones(np.shape(left)))
@@ -99,12 +99,13 @@ def calculate_lick_intervals(behavior_json):
                 for i in np.where(diffs != 0)
             ]
         )[0]
-        cross_side_frac = round(np.mean(cross_sides <= threshold), 4)
+        cross_side_frac = round(np.sum(cross_sides <= threshold)/(len(left)+len(right)), 4)
         CrossSideIntervalPercent = cross_side_frac * 100
+        SameSideIntervalPercent = same_side_frac * 100
         results = {
             "LeftLickIntervalPercent": LeftLickIntervalPercent,
             "RightLickIntervalPercent": RightLickIntervalPercent,
-            "SameSideIntervalPercent": same_side_frac * 100,
+            "SameSideIntervalPercent": SameSideIntervalPercent,
             "CrossSideIntervalPercent": CrossSideIntervalPercent,
         }
         return results

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -118,6 +118,7 @@ def plot_bias(behavior_json,results_folder):
     fig,ax = plt.subplots(nrows=2,figsize=(6,6))
     
     # Set up side bias plot
+    ax[0].set_xlabel('Trial #')
     ax[0].set_ylabel('Side Bias')
     ax[0].axhline(+0.7,color='r', linestyle='--')
     ax[0].axhline(-0.7,color='r', linestyle='--')
@@ -127,61 +128,51 @@ def plot_bias(behavior_json,results_folder):
         ax[0].spines[side].set_visible(False)
         ax[1].spines[side].set_visible(False)
 
-    if len(behavior_json['B_Bias']) == len(behavior_json['B_GoCueTime']):
-        # Bug in older data had only the 200 most recent bias points saved
-        if ('B_Bias_CI' in behavior_json):
-            # If we have the confidence intervals, plot them
-            lower = [x[0] for x in behavior_json['B_Bias_CI']]
-            upper = [x[1] for x in behavior_json['B_Bias_CI']]
-            ax[0].fill_between(
-                np.array(behavior_json['B_GoCueTime'])-behavior_json['B_GoCueTime'][0],
-                behavior_json['B_Bias'], 
-                lower, 
-                upper, 
-                color='gray', 
-                alpha=.5
-                )
-        ax[0].plot(
-            np.array(behavior_json['B_GoCueTime'])-behavior_json['B_GoCueTime'][0],
-            behavior_json['B_Bias'],
-            'k',
-            linewidth=2
+    # If we have the confidence intervals, plot them
+    if ('B_Bias_CI' in behavior_json):
+        lower = [x[0] for x in behavior_json['B_Bias_CI']]
+        upper = [x[1] for x in behavior_json['B_Bias_CI']]
+        ax[0].fill_between(
+            np.arange(0,len(behavior_json['B_Bias'])),
+            behavior_json['B_Bias'], 
+            lower, 
+            upper, 
+            color='gray', 
+            alpha=.5
             )
-        ax[0].set_xlabel('Time from first go cue(s)')
-        stop = behavior_json['B_GoCueTime'][-1] - behavior_json['B_GoCueTime'][0]
-        ax[0].set_xlim([0,stop])
-    else:
+
+    # Plot the bias trace
+    if 'B_Bias' in behavior_json:
         ax[0].plot(behavior_json['B_Bias'],'k',linewidth=2)
         ax[0].set_xlim([0, len(behavior_json['B_Bias'])])
-        ax[0].set_xlabel('Trial #')
 
     if 'B_StagePositions' in behavior_json:
+        # Extract stage positions
         x = [x['x'] for x in behavior_json['B_StagePositions']]
         z = [x['z'] for x in behavior_json['B_StagePositions']]
         if 'y1' in behavior_json['B_StagePositions'][0]:
             y1 = [x['y1'] for x in behavior_json['B_StagePositions']]
             y2 = [x['y2'] for x in behavior_json['B_StagePositions']]
         else:
+            # Convert Newscale from um to mm
             y1 = [x['y']*1000 for x in behavior_json['B_StagePositions']]
             y2 = [x['y']*1000 for x in behavior_json['B_StagePositions']] 
 
-        if len(behavior_json['B_Bias']) == len(behavior_json['B_GoCueTime']):
-            ax[1].plot(behavior_json['B_GoCueTime'],np.array(x)[:-1]-x[0],'r',label='X')
-            ax[1].plot(behavior_json['B_GoCueTime'],np.array(y1)[:-1]-y1[0],'b',label='Y1')
-            ax[1].plot(behavior_json['B_GoCueTime'],np.array(y2)[:-1]-y2[0],'lightblue',label='Y2')
-            ax[1].plot(behavior_json['B_GoCueTime'],np.array(z)[:-1]-z[0],'m',label='Z')
-        else:
-            ax[1].plot(np.array(x)[:-1]-x[0],'r',label='X')
-            ax[1].plot(np.array(y1)[:-1]-y1[0],'b',label='Y1')
-            ax[1].plot(np.array(y2)[:-1]-y2[0],'lightblue',label='Y2')
-            ax[1].plot(np.array(z)[:-1]-z[0],'m',label='Z')
-            ax[1].set_xlim([0, len(behavior_json['B_Bias'])])
-            ax[1].set_xlabel('Trial #')
-
+        # Plot stage positions
+        ax[1].plot(np.array(x)[:-1]-x[0],'r',label='X')
+        ax[1].plot(np.array(y1)[:-1]-y1[0],'b',label='Y1')
+        ax[1].plot(np.array(y2)[:-1]-y2[0],'lightblue',label='Y2')
+        ax[1].plot(np.array(z)[:-1]-z[0],'m',label='Z')
+    
+        # Clean up plot
+        ax[1].set_xlim([0, len(behavior_json['B_Bias'])])
+        ax[1].set_xlabel('Trial #')
         ylims = ax[1].get_ylim()
         ax[1].set_ylim([np.min([-1,ylims[0]]), np.max([1,ylims[1]])])
         ax[1].set_ylabel('Lickspout Position \n relative to session start (mm)')
-        ax[1].legend()           
+        ax[1].legend()          
+    
+    # Save figure 
     plt.savefig(f"{results_folder}/side_bias.png", dpi=300, bbox_inches="tight")
 
 def main():

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -64,19 +64,26 @@ def calculate_lick_intervals(behavior_json):
     right = behavior_json["B_RightLickTime"]
     left = behavior_json["B_LeftLickTime"]
     threshold = 0.05  # time in ms to consider as a fast interval
-    all_licks = np.sort(left +right)
-    all_diffs = np.sort(np.diff(all_licks))
-    ArtifactPercent = np.mean(all_diffs < 0.0005)*100 
+    if (len(left) == 0) and (len(right) == 0):
+        ArtifactPercent = np.nan
+    else:
+        all_licks = np.sort(left +right)
+        all_diffs = np.sort(np.diff(all_licks))
+        ArtifactPercent = np.mean(all_diffs < 0.0005)*100 
     same_side_l = np.diff(left)
     same_side_r = np.diff(right)
     if len(right) > 0:
         # calculate left interval and fraction
         same_side_l_frac = round(np.mean(same_side_l <= threshold), 4)
         LeftLickIntervalPercent = same_side_l_frac * 100
+    else:
+        LeftLickIntervalPercent = np.nan
     if len(left) > 0:
         # calculate right interval and fraction
         same_side_r_frac = round(np.mean(same_side_r <= threshold), 4)
         RightLickIntervalPercent = same_side_r_frac * 100
+    else:
+        RightLickIntervalPercent = np.nan
     if len(right) > 0 and len(left) > 0:
         # calculate same side lick interval and fraction for both right and left
         same_side_combined = np.concatenate([same_side_l, same_side_r])
@@ -105,14 +112,17 @@ def calculate_lick_intervals(behavior_json):
         cross_side_frac = round(np.sum(cross_sides <= threshold)/(len(left)+len(right)), 4)
         CrossSideIntervalPercent = cross_side_frac * 100
         SameSideIntervalPercent = same_side_frac * 100
-        results = {
-            "LeftLickIntervalPercent": LeftLickIntervalPercent,
-            "RightLickIntervalPercent": RightLickIntervalPercent,
-            "SameSideIntervalPercent": SameSideIntervalPercent,
-            "CrossSideIntervalPercent": CrossSideIntervalPercent,
-            "ArtifactPercent": ArtifactPercent,
-        }
-        return results
+    else:
+        CrossSideIntervalPercent = np.nan
+        SameSideIntervalPercent = np.nan
+    results = {
+        "LeftLickIntervalPercent": LeftLickIntervalPercent,
+        "RightLickIntervalPercent": RightLickIntervalPercent,
+        "SameSideIntervalPercent": SameSideIntervalPercent,
+        "CrossSideIntervalPercent": CrossSideIntervalPercent,
+        "ArtifactPercent": ArtifactPercent,
+    }
+    return results
 
 def plot_lick_intervals(behavior_json, results_folder):
     fig, ax = plt.subplots(1,5,figsize=(8,3),sharex=True,sharey=True)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -64,6 +64,9 @@ def calculate_lick_intervals(behavior_json):
     right = behavior_json["B_RightLickTime"]
     left = behavior_json["B_LeftLickTime"]
     threshold = 0.05  # time in ms to consider as a fast interval
+    all_licks = np.sort(left +right)
+    all_diffs = np.sort(np.diff(all_licks))
+    ArtifactPercent = np.mean(all_diffs < 0.0005)*100 
     same_side_l = np.diff(left)
     same_side_r = np.diff(right)
     if len(right) > 0:
@@ -107,6 +110,7 @@ def calculate_lick_intervals(behavior_json):
             "RightLickIntervalPercent": RightLickIntervalPercent,
             "SameSideIntervalPercent": SameSideIntervalPercent,
             "CrossSideIntervalPercent": CrossSideIntervalPercent,
+            "ArtifactPercent": ArtifactPercent,
         }
         return results
 
@@ -406,6 +410,7 @@ def main():
                     QCMetric(
                         name="Left Lick Interval (%)",
                         value=intervals["LeftLickIntervalPercent"],
+                        description = "% of lick intervals < 50ms. These indicate grooming bouts",
                         status_history=[
                             Bool2Status(
                                 intervals["LeftLickIntervalPercent"] < 10,
@@ -417,6 +422,7 @@ def main():
                     QCMetric(
                         name="Right Lick Interval (%)",
                         value=intervals["RightLickIntervalPercent"],
+                        description = "% of lick intervals < 50ms. These indicate grooming bouts",
                         status_history=[
                             Bool2Status(
                                 intervals["RightLickIntervalPercent"] < 10,
@@ -428,9 +434,22 @@ def main():
                     QCMetric(
                         name="Cross Side Lick Interval (%)",
                         value=intervals["CrossSideIntervalPercent"],
+                        description = "% of lick intervals < 50ms. These indicate grooming bouts",
                         status_history=[
                             Bool2Status(
                                 intervals["CrossSideIntervalPercent"] < 10,
+                                t=datetime.now(seattle_tz),
+                            )
+                        ],
+                        reference=str(results_folder / "lick_intervals.png")
+                    ),
+                    QCMetric(
+                        name="Artifact Percent (%)",
+                        value=intervals["ArtifactPercent"],
+                        description="% of lick intervals less than 0.5ms. These indicate electical artifacts",
+                        status_history=[
+                            Bool2Status(
+                                intervals["ArtifactPercent"] < 1,
                                 t=datetime.now(seattle_tz),
                             )
                         ],

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -110,27 +110,46 @@ def calculate_lick_intervals(behavior_json):
         return results
 
 def plot_bias(behavior_json,results_folder):
+    '''
+        Plot a figure of the side bias, and lick spout position
+        behavior_json, the data saved from the GUI
+        results_folder, the place to save the figure
+    '''
     fig,ax = plt.subplots(nrows=2,figsize=(6,6))
+    
+    # Set up side bias plot
     ax[0].set_ylabel('Side Bias')
     ax[0].axhline(+0.7,color='r', linestyle='--')
     ax[0].axhline(-0.7,color='r', linestyle='--')
     ax[0].axhline(0,color='k', linestyle='--')
     ax[0].set_ylim([-1,+1]) 
-    ax[1].set_ylabel('Lickspout Position \n relative to session start (mm)')
     for side in ['top', 'right']:
         ax[0].spines[side].set_visible(False)
         ax[1].spines[side].set_visible(False)
 
     if len(behavior_json['B_Bias']) == len(behavior_json['B_GoCueTime']):
+        # Bug in older data had only the 200 most recent bias points saved
         if ('B_Bias_CI' in behavior_json):
+            # If we have the confidence intervals, plot them
             lower = [x[0] for x in behavior_json['B_Bias_CI']]
             upper = [x[1] for x in behavior_json['B_Bias_CI']]
-            ax[0].fill_between(np.array(behavior_json['B_GoCueTime'])-behavior_json['B_GoCueTime'][0],behavior_json['B_Bias'], lower, upper, color='gray', alpha=.5)
-        ax[0].plot(np.array(behavior_json['B_GoCueTime'])-behavior_json['B_GoCueTime'][0],behavior_json['B_Bias'],'k',linewidth=2)
+            ax[0].fill_between(
+                np.array(behavior_json['B_GoCueTime'])-behavior_json['B_GoCueTime'][0],
+                behavior_json['B_Bias'], 
+                lower, 
+                upper, 
+                color='gray', 
+                alpha=.5
+                )
+        ax[0].plot(
+            np.array(behavior_json['B_GoCueTime'])-behavior_json['B_GoCueTime'][0],
+            behavior_json['B_Bias'],
+            'k',
+            linewidth=2
+            )
         ax[0].set_xlabel('Time from first go cue(s)')
-        start = 0
         stop = behavior_json['B_GoCueTime'][-1] - behavior_json['B_GoCueTime'][0]
-        ax[0].set_xlim([start,stop])
+        ax[0].set_xlim([0,stop])
     else:
         ax[0].plot(behavior_json['B_Bias'],'k',linewidth=2)
         ax[0].set_xlim([0, len(behavior_json['B_Bias'])])
@@ -161,6 +180,7 @@ def plot_bias(behavior_json,results_folder):
 
         ylims = ax[1].get_ylim()
         ax[1].set_ylim([np.min([-1,ylims[0]]), np.max([1,ylims[1]])])
+        ax[1].set_ylabel('Lickspout Position \n relative to session start (mm)')
         ax[1].legend()           
     plt.savefig(f"{results_folder}/side_bias.png", dpi=300, bbox_inches="tight")
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -129,9 +129,6 @@ def main():
     )
 
     session_json = load_json_file(base_path / "session.json")
-    stimulus_start = session_json['stimulus_epochs'][0]['stimulus_start_time']
-    stimulus_end = session_json['stimulus_epochs'][0]['stimulus_end_time']
-    session_length = datetime.fromisoformat(stimulus_end) - datetime.fromisoformat(stimulus_start) 
  
     # Load behavior JSON
     # Regex pattern is <subject_id>_YYYY-MM-DD_HH-MM-SS.json
@@ -298,6 +295,13 @@ def main():
         logging.info("SKIPPING lick interval check")
 
     logging.info("Running session length check")
+    if ('stimulus_epochs' in session_json) and ('stimulus_start_time' in session_json['stimulus_epochs']):
+        stimulus_start = session_json['stimulus_epochs'][0]['stimulus_start_time']
+        stimulus_end = session_json['stimulus_epochs'][0]['stimulus_end_time']
+        session_length = datetime.fromisoformat(stimulus_end) - datetime.fromisoformat(stimulus_start) 
+    else:
+        session_length = timedelta(minutes=0)
+
     evaluations.append(
         create_evaluation(
             "Session Length Check",

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -110,7 +110,7 @@ def calculate_lick_intervals(behavior_json):
         return results
 
 def plot_lick_intervals(behavior_json, results_folder):
-    fig, ax = plt.subplots(5,1,figsize=(6,6),sharex=True,sharey=True)
+    fig, ax = plt.subplots(1,5,figsize=(8,3),sharex=True,sharey=True)
 
     ax[0].set_xlim(-0.01, 0.3)
     ax[0].set_title('left licks')
@@ -118,9 +118,9 @@ def plot_lick_intervals(behavior_json, results_folder):
     ax[2].set_title('left to right licks')
     ax[3].set_title('right to left licks')
     ax[4].set_title('all licks')
-    ax[4].set_xlabel('time (s)')
+    ax[0].set_ylabel('counts')
     for a in ax:
-        a.set_ylabel('counts')
+        a.set_xlabel('time (s)')
         a.spines['top'].set_visible(False)
         a.spines['right'].set_visible(False)
 
@@ -175,7 +175,6 @@ def plot_lick_intervals(behavior_json, results_folder):
 
     plt.tight_layout()
     plt.savefig(f"{results_folder}/lick_intervals.png", dpi=300, bbox_inches="tight")
-
 
 def plot_bias(behavior_json,results_folder):
     '''

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -291,7 +291,8 @@ def main():
     if matching_behavior_files:
         behavior_json = load_json_file(matching_behavior_files[0])
     else:
-        logging.info("NO BEHAVIOR JSON")
+        logging.info("NO BEHAVIOR JSON, cannot run QC")
+        return
 
     # Create bias plot
     plot_bias(behavior_json,results_folder)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -109,12 +109,34 @@ def calculate_lick_intervals(behavior_json):
         }
         return results
 
+def plot_bias(behavior_json):
+    plt.figure()
+    plt.xlabel('Time from first go cue(s)')
+    plt.ylabel('Side Bias')
+    plt.axhline(+0.7,color='r', linestyle='--')
+    plt.axhline(-0.7,color='r', linestyle='--')
+    plt.axhline(0,color='k', linestyle='--')
+    plt.ylim([-1,+1]) 
+
+    if len(behavior_json['B_GoCueTime']) == len(behavior_json['B_GoCueTime'):
+        plt.plot(np.array(behavior_json['B_GoCueTime'])-behavior_json['B_GoCueTime'][0],behavior_json['B_Bias'],'k',linewidth=2)
+        start = 0
+        stop = behavior_json['B_GoCueTime'][-1] - behavior_json['B_GoCueTime'][0]
+        plt.xlim([start,stop])
+    else:
+        plt.plot(behavior_json['B_Bias'],'k',linewidth=2)
+
+    plt.savefig(f"{results_folder}/side_bias.png", dpi=300, bbox_inches="tight")
 
 def main():
     # Paths and setup
     base_path = Path("/data/fiber_raw_data")
     results_folder = Path("../results")
     results_folder.mkdir(parents=True, exist_ok=True)
+    qc_folder = Path("../results/qc-raw")
+    qc_folder.mkdir(parents=True, exist_ok=True)
+
+    ref_folder = Path("qc-raw")
 
     # Load JSON files
     subject_data = load_json_file(base_path / "subject.json")
@@ -129,6 +151,7 @@ def main():
     )
 
     session_json = load_json_file(base_path / "session.json")
+    plot_bias(behavior_json,results_folder)
  
     # Load behavior JSON
     # Regex pattern is <subject_id>_YYYY-MM-DD_HH-MM-SS.json
@@ -233,6 +256,7 @@ def main():
                                 np.abs(mean_bias) < 0.75, t=datetime.now(seattle_tz)
                             )
                         ],
+                        reference=str(ref_folder / "side_bias.png")
                     ),
                     QCMetric(
                         name="Max side bias",
@@ -242,6 +266,7 @@ def main():
                                 np.abs(max_bias) < 1, t=datetime.now(seattle_tz)
                             )
                         ],
+                        reference=str(ref_folder / "side_bias.png")
                     ),
                 ],
             )
@@ -331,6 +356,8 @@ def main():
             ],
         )
     )
+
+    # TODO - move files?
 
     # Create QC object and save
     qc = QualityControl(evaluations=evaluations)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -186,7 +186,7 @@ def plot_bias(behavior_json,results_folder):
 
 def main():
     # Paths and setup
-    base_path = Path("/data/fiber_raw_data_3")
+    base_path = Path("/data/fiber_raw_data")
     results_folder = Path("../results/aind-dynamic-foraging-qc")
     results_folder.mkdir(parents=True, exist_ok=True)
 
@@ -207,7 +207,7 @@ def main():
  
     # Load behavior JSON
     # Regex pattern is <subject_id>_YYYY-MM-DD_HH-MM-SS.json
-    pattern = "/data/fiber_raw_data_3/behavior/[0-9]*_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]-[0-9][0-9]-[0-9][0-9].json"
+    pattern = "/data/fiber_raw_data/behavior/[0-9]*_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]-[0-9][0-9]-[0-9][0-9].json"
     matching_behavior_files = glob.glob(pattern)
     if matching_behavior_files:
         behavior_json = load_json_file(matching_behavior_files[0])

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -269,6 +269,8 @@ def main():
     base_path = Path("/data/fiber_raw_data")
     results_folder = Path("../results/aind-dynamic-foraging-qc")
     results_folder.mkdir(parents=True, exist_ok=True)
+    reference_folder = Path("aind-dynamic-foraging-qc")
+    reference_folder.mkdir(parents=True, exist_ok=True)
 
     # Load JSON files
     subject_data = load_json_file(base_path / "subject.json")
@@ -395,7 +397,7 @@ def main():
                                 np.abs(mean_bias) < 0.5, t=datetime.now(seattle_tz)
                             )
                         ],
-                        reference=str(results_folder / "side_bias.png")
+                        reference=str(reference_folder / "side_bias.png")
                     ),
                     QCMetric(
                         name="Max side bias",
@@ -406,7 +408,7 @@ def main():
                                 np.abs(max_bias) < 1, t=datetime.now(seattle_tz)
                             )
                         ],
-                        reference=str(results_folder / "side_bias.png")
+                        reference=str(reference_folder / "side_bias.png")
                     ),
                 ],
             )
@@ -433,7 +435,7 @@ def main():
                                 t=datetime.now(seattle_tz),
                             )
                         ],
-                        reference=str(results_folder / "lick_intervals.png")
+                        reference=str(reference_folder / "lick_intervals.png")
                     ),
                     QCMetric(
                         name="Right Lick Interval (%)",
@@ -445,7 +447,7 @@ def main():
                                 t=datetime.now(seattle_tz),
                             )
                         ],
-                        reference=str(results_folder / "lick_intervals.png")
+                        reference=str(reference_folder / "lick_intervals.png")
                     ),
                     QCMetric(
                         name="Cross Side Lick Interval (%)",
@@ -457,7 +459,7 @@ def main():
                                 t=datetime.now(seattle_tz),
                             )
                         ],
-                        reference=str(results_folder / "lick_intervals.png")
+                        reference=str(reference_folder / "lick_intervals.png")
                     ),
                     QCMetric(
                         name="Artifact Percent (%)",
@@ -469,7 +471,7 @@ def main():
                                 t=datetime.now(seattle_tz),
                             )
                         ],
-                        reference=str(results_folder / "lick_intervals.png")
+                        reference=str(reference_folder / "lick_intervals.png")
                     ),
                 ],
             )

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -63,27 +63,31 @@ def create_evaluation(
 def calculate_lick_intervals(behavior_json):
     right = behavior_json["B_RightLickTime"]
     left = behavior_json["B_LeftLickTime"]
+    same_side_l = np.diff(left)
+    same_side_r = np.diff(right)
     threshold = 0.05  # time in ms to consider as a fast interval
+
     if (len(left) == 0) and (len(right) == 0):
         ArtifactPercent = np.nan
     else:
         all_licks = np.sort(left +right)
         all_diffs = np.sort(np.diff(all_licks))
-        ArtifactPercent = np.mean(all_diffs < 0.0005)*100 
-    same_side_l = np.diff(left)
-    same_side_r = np.diff(right)
-    if len(right) > 0:
+        ArtifactPercent = np.mean(all_diffs < 0.0005)*100
+ 
+    if len(left) > 0:
         # calculate left interval and fraction
         same_side_l_frac = round(np.mean(same_side_l <= threshold), 4)
         LeftLickIntervalPercent = same_side_l_frac * 100
     else:
         LeftLickIntervalPercent = np.nan
-    if len(left) > 0:
+
+    if len(right) > 0:
         # calculate right interval and fraction
         same_side_r_frac = round(np.mean(same_side_r <= threshold), 4)
         RightLickIntervalPercent = same_side_r_frac * 100
     else:
         RightLickIntervalPercent = np.nan
+
     if len(right) > 0 and len(left) > 0:
         # calculate same side lick interval and fraction for both right and left
         same_side_combined = np.concatenate([same_side_l, same_side_r])


### PR DESCRIPTION
- merging experimenter name and dirty file check into "basic configuration" check
- Organizes minimum trial number and new metric minimum stimulus length into "session length" check
- Adds a plot of the side bias over the course of the session
- Adds a plot of lick intervals.
- Changes the calculation of cross side lick intervals to be a percentage of all licks, instead of just cross licks
- Adds a metric for electrical artifacts that are extremely fast intervals. 
- Also fixes the case of no behavior JSON file by returning and not generating a QC report

Here is what the side bias plot looks like
![side_bias](https://github.com/user-attachments/assets/023c59d7-8e19-4cd7-a09d-319a3abfa61c)

Here is a passing lick interval
- behavior_765232_2025-02-20_18-28-06
![lick_intervals_good](https://github.com/user-attachments/assets/4d4102b9-3c54-48c1-a8fc-93603748bafc)

Here is a failing lick interval (electrical artifact)
- behavior_753618_2025-02-20
![lick_intervals_bad](https://github.com/user-attachments/assets/ce8978b7-5275-4fc7-8ee3-785b0e66be46)

